### PR TITLE
当 .signore 中只包含 /src/ 时不应该忽略 node_modules/debug/src/index.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.idea
 node_modules
 .s
 
 package-lock.json
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -41,10 +41,17 @@
     "tty-table": "^4.1.5"
   },
   "devDependencies": {
+    "@types/jest": "^27.5.1",
     "@types/node": "^14.0.23",
     "esbuild": "^0.13.8",
+    "jest": "^28.1.0",
     "rimraf": "^3.0.2",
+    "ts-jest": "^28.0.2",
     "ts-node": "^8.10.2",
     "typescript": "^4.4.2"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
   },
   "dependencies": {
     "@serverless-devs/core": "latest",
-    "random-string": "^0.2.0",
-    "opn": "^0.1.2",
-    "request": "^2.88.2",
     "fs": "^0.0.1-security",
-    "request-promise": "4.2.6",
-    "table": "^6.8.0",
     "git-ignore-parser": "0.0.2",
     "lodash": "^4.17.21",
     "md5-file": "^5.0.0",
+    "opn": "^0.1.2",
+    "path": "^0.12.7",
     "progress": "^2.0.3",
-    "tty-table": "^4.1.5",
-    "path": "^0.12.7"
+    "random-string": "^0.2.0",
+    "request": "^2.88.2",
+    "request-promise": "4.2.6",
+    "table": "^6.8.0",
+    "tty-table": "^4.1.5"
   },
   "devDependencies": {
     "@types/node": "^14.0.23",

--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -51,6 +51,23 @@ export async function isIgnoredInCodeUri(actualCodeUri: string, runtime: string)
   };
 }
 
+export async function isIgnoredInCodeUri2(actualCodeUri: string, runtime: string): Promise<Function> {
+  const ignoreFilePath = path.join(actualCodeUri, '.signore');
+
+  const fileContent: string = await getIgnoreContent(ignoreFilePath);
+  const fileContentList: string[] = fileContent.split('\n');
+  const ignoreDependencies = selectIgnored(runtime);
+
+  let array = ignoredFile.concat(ignoreDependencies).concat(fileContentList);
+  const ig = ignore().add(array);
+
+  return function (f) {
+    const relativePath = path.relative(actualCodeUri, f);
+    if (relativePath === '') { return false; }
+    return ig.ignores(relativePath);
+  };
+}
+
 export async function isIgnored(baseDir: string, runtime: string, actualCodeUri: string, ignoreRelativePath?: string): Promise<Function> {
   const ignoreFilePath = path.join(baseDir, '.signore');
 

--- a/test/ignore.spec.ts
+++ b/test/ignore.spec.ts
@@ -1,0 +1,83 @@
+import {fse, ignore} from "@serverless-devs/core";
+import * as os from "os";
+import path from "path";
+import {isIgnoredInCodeUri} from "../src/ignore";
+import {randomInt} from "crypto";
+
+describe('isIgnoredInCodeUri', () => {
+    let debugIndex = 'node_modules/debug/src/index.js';
+    let srcIndex = 'src/index.ts';
+    let distIndex = 'dist/index.js';
+    let dir: string;
+    let debugIndexAbsPath: string;
+    let srcIndexAbsPath: string;
+    let distIndexAbsPath: string;
+
+    beforeEach(() => {
+        dir = path.join(os.tmpdir(), 'is-ignored-in-code-uri-playground-' + randomInt(100));
+        console.log(`setting up playground ${dir}`);
+
+        debugIndexAbsPath = path.join(dir, debugIndex);
+        srcIndexAbsPath = path.join(dir, srcIndex);
+        distIndexAbsPath = path.join(dir, distIndex);
+
+        fse.ensureDir(dir);
+        fse.ensureFile(debugIndexAbsPath);
+        fse.ensureFile(srcIndexAbsPath);
+        fse.ensureFile(distIndexAbsPath);
+    });
+
+    afterEach(() => {
+        fse.removeSync(dir);
+    });
+
+    // copied from https://git-scm.com/docs/gitignore#_pattern_format
+    //
+    // If there is a separator at the beginning or middle (or both) of the pattern,
+    // then the pattern is relative to the directory level of the particular .gitignore file itself.
+    // Otherwise the pattern may also match at any level below the .gitignore level.
+    //
+    // If there is a separator at the end of the pattern then the pattern will only match directories,
+    // otherwise the pattern can match both files and directories.
+    //
+    // For example, a pattern `doc/frotz/` matches `doc/frotz` directory, but not `a/doc/frotz` directory;
+    // however `frotz/` matches `frotz` and `a/frotz` that is a directory (all paths are relative from the .gitignore file).
+    //
+    // so the `/src/` should only ignore src/index.ts as expected.
+
+    test('node_modules/debug/src/index.js should not be ignored when specified /src/ in .signore', async function () {
+        let signoreContent = [
+            '/src/'
+        ];
+
+        await testSIgnoreContent(signoreContent);
+    });
+
+    test('node_modules/debug/src/index.js should not be ignored when specified /src/ in .signore workaround', async function () {
+        let signoreContent = [
+            '!/node_modules/**/src/',
+            '/src/'
+        ];
+
+        await testSIgnoreContent(signoreContent);
+    });
+
+    async function testSIgnoreContent(signoreContent: Array<string>) {
+        fse.outputFileSync(path.resolve(dir, '.signore'), signoreContent.join('\r\n'))
+        let i = ignore().add(signoreContent);
+
+        let f = await isIgnoredInCodeUri(dir, 'invalid-runtime');
+
+        expect(i.ignores(srcIndex)).toBeTruthy();
+        expect(f(srcIndexAbsPath)).toBeTruthy();
+        console.log(`${srcIndex} ignored`);
+
+        expect(i.ignores(distIndex)).toBeFalsy();
+        expect(f(distIndexAbsPath)).toBeFalsy();
+        console.log(`${distIndex} kept`);
+
+        expect(i.ignores(debugIndex)).toBeFalsy();
+        expect(f(debugIndexAbsPath)).toBeFalsy(); // this should pass as described above
+        console.log(`${debugIndex} kept`);
+    }
+});


### PR DESCRIPTION
根据 https://git-scm.com/docs/gitignore#_pattern_format 中的描述:

> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. Otherwise the pattern may also match at any level below the .gitignore level.
>
> If there is a separator at the end of the pattern then the pattern will only match directories, otherwise the pattern can match both files and directories.
>
> For example, a pattern `doc/frotz/` matches `doc/frotz` directory, but not `a/doc/frotz` directory; however `frotz/` matches `frotz` and `a/frotz` that is a directory (all paths are relative from the .gitignore file).

可以认为 `/src/` 应当只忽略当前目录下的 `src` 文件夹, 但现有的 `isIgnoredInCodeUri` 和 `isIgnored` 都使用了 https://www.npmjs.com/package/git-ignore-parser 对 `.signore` 中的内容进行过滤, 导致过滤后的规则将 `node_modules/debug/src/index.js` 也忽略掉了.

复现步骤详见测试用例.

### WARN: 合并这个 PR 可能会导致解析现有的 .signore 规则时出现意料以外的行为.